### PR TITLE
Tile Merge - Change project method and use GDAL's warp call.

### DIFF
--- a/MODIS/lib/tile_file.py
+++ b/MODIS/lib/tile_file.py
@@ -1,6 +1,6 @@
 # Trimmed down version of gdal's distributed gdal_merge.py helper script
 
-from osgeo import gdal, gdalnumeric
+from osgeo import gdal, gdalconst, gdalnumeric
 
 FILTER_TYPE_LIMITS = {
     'forcing': {
@@ -32,7 +32,7 @@ class TileFile:
                        lower limit to filter band values.
 
         """
-        tile_file = gdal.Open(filename)
+        tile_file = gdal.Open(filename, gdalconst.GA_ReadOnly)
 
         self.filename = filename
         self.bands = tile_file.RasterCount
@@ -89,7 +89,7 @@ class TileFile:
         tw_xoff = int((tgw_ulx - t_ulx) / t_pixel_width + 0.1)
         tw_yoff = int((tgw_uly - t_uly) / t_pixel_height + 0.1)
 
-        source_file = gdal.Open(self.filename, gdal.GA_ReadOnly)
+        source_file = gdal.Open(self.filename, gdalconst.GA_ReadOnly)
 
         target_band = output_file.GetRasterBand(target_band)
 

--- a/MODIS/lib/tile_merger.py
+++ b/MODIS/lib/tile_merger.py
@@ -140,16 +140,4 @@ class TileMerger:
     def project(self):
         print('Generating projected output file: ' + self.output_file_name)
 
-        # Call AutoCreateWarpedVRT() to fetch default values for target
-        # raster dimensions and geotransform
-        tmp_ds = gdal.AutoCreateWarpedVRT(self.output_file,
-                                          None,  # src_wkt : left to default value
-                                          OUTPUT_PROJECTION.ExportToWkt(),
-                                          gdal.GRA_NearestNeighbour,
-                                          0.125  # same value as in gdalwarp
-                                          )
-
-        gdal.GetDriverByName(OUTPUT_FORMAT).CreateCopy(self.output_file_name, tmp_ds)
-
-        # Release all file handlers
-        del tmp_ds
+        gdal.Warp(self.output_file_name, self.output_file, dstSRS='EPSG:4326')


### PR DESCRIPTION
GDAL exposes their command tools via Python interface and reduces
logic needed to warp. This also ensures all proper actions are
done to warp the final tile.